### PR TITLE
fix: update error handling to use anyhow instead of error-chain. fix failing tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,22 +5,23 @@ authors = ["Joe Paul <joeirimpan@gmail.com>"]
 description = "RUST API wrapper for kiteconnect APIs"
 license = "MIT"
 repository = "https://github.com/zerodhatech/kiteconnect-rust"
+edition = "2018"
 
 [dependencies]
 reqwest = "0.9.0"
 serde = "1.0.24"
 serde_derive = "1.0.27"
 serde_json = "1.0"
-error-chain = "0.12.0"
 rust-crypto = "0.2.36"
 url = "1.5"
 byteorder = "1.2.1"
 log = "0.4.1"
 csv = "1.0.0-beta.5"
+anyhow = "1.0"
 
 [dependencies.ws]
 version = "0.7.3"
 features = ["ssl"]
 
 [dev-dependencies]
-mockito = "0.9.0"
+mockito = "0.27.0"

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -123,7 +123,7 @@ impl KiteConnect {
 
         let mut resp = self.send_request(url, "POST", Some(data))?;
 
-        if resp.status().as_u16() == 200 {
+        if resp.status().is_success() {
             let jsn: JsonValue = resp.json()?;
             self.set_access_token(jsn["data"]["access_token"].as_str().unwrap());
             Ok(jsn)
@@ -164,7 +164,7 @@ impl KiteConnect {
 
         let mut resp = self.send_request(url, "POST", Some(data))?;
 
-        if resp.status().as_u16() == 200 {
+        if resp.status().is_success() {
             let jsn: JsonValue = resp.json()?;
             self.set_access_token(jsn["access_token"].as_str().unwrap());
             Ok(jsn)

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -81,7 +81,7 @@ impl KiteConnect {
             let jsn: JsonValue = resp.json().with_context(|| "Serialization failed")?;
             Ok(jsn)
         } else {
-            Err(anyhow!("Request failed!"))
+            Err(anyhow!(resp.text()?))
         }
     }
 
@@ -128,7 +128,7 @@ impl KiteConnect {
             self.set_access_token(jsn["data"]["access_token"].as_str().unwrap());
             Ok(jsn)
         } else {
-            Err(anyhow!("Session generation failed!"))
+            Err(anyhow!(resp.text()?))
         }
     }
 
@@ -169,7 +169,7 @@ impl KiteConnect {
             self.set_access_token(jsn["access_token"].as_str().unwrap());
             Ok(jsn)
         } else {
-            Err(anyhow!("Couldn't renew access token!"))
+            Err(anyhow!(resp.text()?))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,11 @@
 //! ```
 //! 
 //! # Ticker
-//! ```rust
+//! ```rust, no_run
 //! extern crate kiteconnect;
 //! extern crate serde_json as json;
 //! 
-//! use kiteconnect::ticker::{KiteTicker, KiteTickerHandler, WebSocketHandler}
+//! use kiteconnect::ticker::{KiteTicker, KiteTickerHandler, WebSocketHandler};
 //! 
 //! #[derive(Debug)]
 //! struct CustomHandler {
@@ -95,21 +95,12 @@
 //! # }
 //! ```
 //!
-#[macro_use]
-extern crate error_chain;
-extern crate reqwest;
-extern crate serde;
-#[macro_use]
-extern crate serde_json;
-extern crate crypto;
 #[cfg(test)]
 extern crate mockito;
 extern crate csv;
 extern crate ws;
 extern crate url;
 extern crate byteorder;
-#[macro_use]
-extern crate log;
 
 pub mod connect;
 pub mod ticker;


### PR DESCRIPTION
`error-chain` is deprecated so switched to [`anyhow`](https://docs.rs/anyhow/1.0.32/anyhow/) instead
update Rust edition to 2018. remove unnecessary macro_use statements
bump mockito version
fix docs